### PR TITLE
docs: symlink africa specific profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build configuration for Africa CDC SARS-CoV-2 builds hosted at https://nextstrai
 git clone https://github.com/nextstrain/ncov-africa-cdc.git
 git clone https://github.com/nextstrain/ncov.git
 cd ncov
-ln -s ../ncov-africa-cdc/africa_cdc_profile .
+cp -r ../ncov-africa-cdc/africa_cdc_profile .
 ```
 
 ### Download data


### PR DESCRIPTION
### Description of proposed changes    

To fix:

```
MissingInputException in line 1346 of ${PWD}/ncov/workflow/snakemake_rules/main_workflow.smk:
Missing input files for rule build_description:
africa_cdc_profile/description_africa.md
```

### Testing

Spell check, and maybe run the example commands.
