### PR TITLE
Use seqkit grep instead of faSomeRecords for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ xz -c -d data/metadata_africa.tsv.xz \
 
 # Get genomes for strain names from tarball.
 tar xOf data/sequences_fasta.tar.xz sequences.fasta \
-  | faSomeRecords /dev/stdin data/strains_africa.txt /dev/stdout \
+  | seqkit grep -n -f data/strains_africa.txt \
   | xz -c -2 > data/sequences_africa.fasta.xz
 ```
 

--- a/builds_africa.yaml
+++ b/builds_africa.yaml
@@ -45,11 +45,6 @@ builds:
     title: SARS-CoV-2 analysis for Western Africa
     subsampling_scheme: african_region
     countries: "'Benin', 'Burkina Faso', 'Cabo Verde', 'Cote d\\'Ivoire', 'Gambia', 'Ghana', 'Guinea', 'Guinea-Bissau', 'Liberia', 'Mali', 'Niger', 'Nigeria', 'Senegal', 'Sierra Leone', 'Togo'"
-  # Define institutional builds
-  CAMES:
-    title: SARS-CoV-2 analysis for CAMES countries
-    subsampling_scheme: african_institution
-    countries: "'Benin', 'Burkina Faso', 'Burundi', 'Cameroon', 'Central African Republic', 'Republic of the Congo', 'Cote d\\'Ivoire', 'Gabon', 'Guinea', 'Guinea-Bissau', 'Equatorial Guinea', 'Madagascar', 'Mali', 'Niger', 'Democratic Republic of the Congo', 'Rwanda', 'Chad', 'Senegal', 'Togo'" 
   # Define country-specific builds.
   algeria:
     colors: africa_cdc_profile/colors/algeria_colors.tsv
@@ -316,17 +311,6 @@ subsampling:
 
   african_region:
     # Sample each region evenly by country, year, and month.
-    focal:
-      group_by: country year month
-      max_sequences: 5000
-      query: --query "(gisaid_africa == 'yes') & (country in [{countries}])"
-    # Use all contextual data from the nextregions input without any subsampling.
-    context:
-      max_sequences: 1000
-      query: --query "(nextregions_africa == 'yes') & (country not in [{countries}])"
-
-  african_institution:
-    # Sample each institution evenly by country, year, and month.
     focal:
       group_by: country year month
       max_sequences: 5000

--- a/builds_africa.yaml
+++ b/builds_africa.yaml
@@ -43,7 +43,11 @@ builds:
     title: SARS-CoV-2 analysis for Western Africa
     subsampling_scheme: african_region
     countries: "'Benin', 'Burkina Faso', 'Cabo Verde', 'Cote d\\'Ivoire', 'Gambia', 'Ghana', 'Guinea', 'Guinea-Bissau', 'Liberia', 'Mali', 'Niger', 'Nigeria', 'Senegal', 'Sierra Leone', 'Togo'"
-
+  # Define institutional builds
+  CAMES:
+    title: SARS-CoV-2 analysis for CAMES countries
+    subsampling_scheme: african_institution
+    countries: "'Benin', 'Burkina Faso', 'Burundi', 'Cameroon', 'Central African Republic', 'Republic of the Congo', 'Cote d\\'Ivoire', 'Gabon', 'Guinea', 'Guinea-Bissau', 'Equatorial Guinea', 'Madagascar', 'Mali', 'Niger', 'Democratic Republic of the Congo', 'Rwanda', 'Chad', 'Senegal', 'Togo'" 
   # Define country-specific builds.
   algeria:
     colors: africa_cdc_profile/colors/algeria_colors.tsv
@@ -310,6 +314,17 @@ subsampling:
 
   african_region:
     # Sample each region evenly by country, year, and month.
+    focal:
+      group_by: country year month
+      max_sequences: 5000
+      query: --query "(gisaid_africa == 'yes') & (country in [{countries}])"
+    # Use all contextual data from the nextregions input without any subsampling.
+    context:
+      max_sequences: 1000
+      query: --query "(nextregions_africa == 'yes') & (country not in [{countries}])"
+
+  african_institution:
+    # Sample each institution evenly by country, year, and month.
     focal:
       group_by: country year month
       max_sequences: 5000


### PR DESCRIPTION
### Description of proposed changes
I am opening this pull request to suggest the use of ```seqkit grep``` instead of ```faSomeRecords``` to extract Africans fasta records from the ```sequences_fasta.tar.xz``` file downloaded from GISAID.
### Related issue(s)
I am making this suggestion because I noticed recently that the number of fasta records in the ```sequences_africa.fasta``` file obtained exceeds the number of entries in the ```strains_africa.txt``` file. 
<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
