### PR TITLE
Filter sequences by full name/description instead of id

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,10 @@ Select the “metadata” button from that same “Download packages” section 
 
 ### Filter data
 
-From an existing `nextstrain` conda environment, install extra tools to extract data from GISAID files.
+Navigate to the `ncov` workflow directory and enter a Nextstrain runtime shell there.
 
 ```
-# Install tsvutils and UCSC command to extract sequences.
-# You only need to do this once.
-conda activate nextstrain
-conda install -c conda-forge -c bioconda tsv-utils ucsc-fasomerecords
+nextstrain shell .
 ```
 
 Extract African metadata and sequences from full GISAID downloads.
@@ -52,7 +49,7 @@ xz -c -d data/metadata_africa.tsv.xz \
 
 # Get genomes for strain names from tarball.
 tar xOf data/sequences_fasta.tar.xz sequences.fasta \
-  | faSomeRecords /dev/stdin data/strains_africa.txt /dev/stdout \
+  | seqkit grep --by-name -f data/strains_africa.txt \
   | xz -c -2 > data/sequences_africa.fasta.xz
 ```
 


### PR DESCRIPTION
Switches from faSomeRecords to seqkit grep in order to do so.

faSomeRecords only matches on the FASTA id¹, so filtering for

    hCov-19/South Africa/…

will also include sequences like

    hCov-19/South Korea/…

This repo's sequence selection list (data/strains_africa.txt) contains the full FASTA name/description for each sequence (as id isn't unique in this data), so using faSomeRecords is not appropriate.

seqkit grep also defaults to matching on the id just like faSomeRecords, but the --by name option changes it to match on the full name/description.  That's what we need.

Avoiding faSomeRecords is also useful because, unlike seqkit, it's not in our Nextstrain runtimes.

¹ The id is the part between the initial ">" and the first space, e.g. in ">x y z" the id is "x" and the full name/description is "x y z".

Related-to: <https://github.com/nextstrain/ncov-africa-cdc/pull/7>

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
